### PR TITLE
Use Connections JSON API instead of browser automation

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,37 +1,112 @@
-const { chromium } = require('playwright');
 const fs = require('fs');
+const path = require('path');
 
-async function scrapeNYT() {
-    const browser = await chromium.launch();
-    const page = await browser.newPage();
-    await page.goto('https://www.nytimes.com/games/connections');
+const CONNECTIONS_ENDPOINT = 'https://www.nytimes.com/svc/connections/v2';
+const BOARD_SIZE = 16;
+const ROW_LENGTH = 4;
 
-    // Check for and click the blocker card button if it exists
-    const blockerButton = await page.$("body > .purr-blocker-card button");
-    if (blockerButton) {
-        await blockerButton.click();
+function parseArguments() {
+  const args = process.argv.slice(2);
+  let dateArg;
+  let includeAnswers = false;
+
+  for (const arg of args) {
+    if (arg === '--include-answers') {
+      includeAnswers = true;
+      continue;
     }
 
-    // Click the "Play" button
-    await page.click('button:text("Play")');
-
-    // Wait for the items to load and select them
-    const checkboxValues = [];
-    await page.waitForSelector('label input[type=checkbox]');
-    const checkboxes = await page.$$('label input[type=checkbox]');
-    for (const checkbox of checkboxes) {
-        checkboxValues.push(await checkbox.inputValue());
+    if (!dateArg && /^\d{4}-\d{2}-\d{2}$/.test(arg)) {
+      dateArg = arg;
+      continue;
     }
 
-    // Format the grid data into a 4x4 array
-    const grid4x4 = [];
-    while (checkboxValues.length) grid4x4.push(checkboxValues.splice(0, 4));
+    console.error('Usage: node index.js [YYYY-MM-DD] [--include-answers]');
+    process.exit(1);
+  }
 
-    // Output to JSON file with today's date
-    const fileName = `data/${new Date().toISOString().split('T')[0]}.json`;
-    fs.writeFileSync(fileName, JSON.stringify(grid4x4, null, 2));
-
-    await browser.close();
+  const date = dateArg ?? new Date().toISOString().split('T')[0];
+  return { date, includeAnswers };
 }
 
-scrapeNYT();
+async function fetchPuzzle(date) {
+  const response = await fetch(`${CONNECTIONS_ENDPOINT}/${date}.json`, {
+    headers: {
+      'User-Agent': 'Mozilla/5.0 (compatible; connections-scraper/1.0)',
+      Accept: 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch puzzle for ${date}: ${response.status} ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+function buildBoard(categories) {
+  const board = Array(BOARD_SIZE).fill(null);
+
+  for (const category of categories) {
+    for (const card of category.cards) {
+      const { position, content } = card;
+
+      if (typeof position !== 'number' || position < 0 || position >= BOARD_SIZE) {
+        throw new Error(`Encountered invalid card position: ${JSON.stringify(card)}`);
+      }
+
+      board[position] = content;
+    }
+  }
+
+  if (board.some((cell) => cell === null)) {
+    throw new Error('Puzzle data is missing one or more card positions.');
+  }
+
+  const rows = [];
+  for (let i = 0; i < BOARD_SIZE; i += ROW_LENGTH) {
+    rows.push(board.slice(i, i + ROW_LENGTH));
+  }
+
+  return rows;
+}
+
+function formatCategories(categories) {
+  return categories.map((category) => ({
+    title: category.title,
+    members: category.cards.map((card) => card.content),
+  }));
+}
+
+async function main() {
+  const { date, includeAnswers } = parseArguments();
+
+  try {
+    const puzzle = await fetchPuzzle(date);
+    const rows = buildBoard(puzzle.categories);
+
+    const outputDir = path.join(__dirname, 'data');
+    fs.mkdirSync(outputDir, { recursive: true });
+
+    const boardPath = path.join(outputDir, `${date}.json`);
+    fs.writeFileSync(boardPath, JSON.stringify(rows, null, 2));
+    console.log(`Saved board to ${boardPath}`);
+
+    if (includeAnswers) {
+      const answersPath = path.join(outputDir, `${date}.answers.json`);
+      const payload = {
+        id: puzzle.id ?? null,
+        print_date: puzzle.print_date ?? date,
+        editor: puzzle.editor ?? null,
+        categories: formatCategories(puzzle.categories),
+      };
+      fs.writeFileSync(answersPath, JSON.stringify(payload, null, 2));
+      console.log(`Saved answers to ${answersPath}`);
+    }
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}
+
+main();

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,51 +6,7 @@
   "packages": {
     "": {
       "name": "nytimes-connections-automation",
-      "version": "1.0.0",
-      "dependencies": {
-        "playwright": "^1.20.0"
-      }
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/playwright": {
-      "version": "1.39.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.39.0.tgz",
-      "integrity": "sha512-naE5QT11uC/Oiq0BwZ50gDmy8c8WLPRTEWuSSFVG2egBka/1qMoSqYQcROMT9zLwJ86oPofcTH2jBY/5wWOgIw==",
-      "dependencies": {
-        "playwright-core": "1.39.0"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/playwright-core": {
-      "version": "1.39.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.39.0.tgz",
-      "integrity": "sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==",
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=16"
-      }
+      "version": "1.0.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,8 +5,5 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js"
-  },
-  "dependencies": {
-    "playwright": "^1.20.0"
   }
 }


### PR DESCRIPTION
## Summary
- replace the Playwright-based browser automation with a direct call to the NYT Connections v2 JSON API
- reconstruct the 4×4 board from API card positions and optionally write the grouped answers metadata
- remove the unused Playwright dependency and shrink the package lock

## Testing
- not run (NYTimes endpoints return 403 from the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d98ea5801c83298f988f7ff3f53b2c